### PR TITLE
Replace c++14 return (void) with classic style

### DIFF
--- a/src/ofxJsonParseFunctions.h
+++ b/src/ofxJsonParseFunctions.h
@@ -45,12 +45,18 @@ namespace ofx {
         static constexpr char const skip_json_isnt_object_or_array[] = "skip: json isn't object or array.";
         
         inline void parse(const ofJson &json, std::string &value) {
-            if(!json.is_string()) return ofLogVerbose("ofxJsonUtils::parse string") << skip_json_isnt_string;
+            if(!json.is_string()) {
+                ofLogVerbose("ofxJsonUtils::parse string") << skip_json_isnt_string;
+                return;
+            }
             value = json;
         }
         
         inline void parse(const ofJson &json, bool &value) {
-            if(!json.is_boolean()) return ofLogVerbose("ofxJsonUtils::parse boolean") << skip_json_isnt_boolean;
+            if(!json.is_boolean()) {
+                ofLogVerbose("ofxJsonUtils::parse boolean") << skip_json_isnt_boolean;
+                return;
+            }
             value = json;
         }
         
@@ -70,10 +76,16 @@ namespace ofx {
         static void parse(const ofJson &json, ofVec2f &v) {
             if(json.is_object()) {
                 auto end = json.end();
-                if(!detail::has_keys(json, {"x", "y"})) return ofLogVerbose("ofxJsonUtils::parse ofVec2f") << skip_invalid_format;
+                if(!detail::has_keys(json, {"x", "y"})) {
+                    ofLogVerbose("ofxJsonUtils::parse ofVec2f") << skip_invalid_format;
+                    return;
+                }
                 v.set(json["x"], json["y"]);
             } else if(json.is_array()) {
-                if(json.size() < 2) return ofLogVerbose("ofxJsonUtils::parse ofVec2f") << skip_invalid_format;
+                if(json.size() < 2) {
+                    ofLogVerbose("ofxJsonUtils::parse ofVec2f") << skip_invalid_format;
+                    return;
+                }
                 v.set(json[0], json[1]);
             } else {
                 ofLogVerbose("ofxJsonUtils::parse ofVec2f") << skip_json_isnt_object_or_array;
@@ -83,10 +95,16 @@ namespace ofx {
         static void parse(const ofJson &json, ofVec3f &v) {
             if(json.is_object()) {
                 auto end = json.end();
-                if(!detail::has_keys(json, {"x", "y", "z"})) return ofLogVerbose("ofxJsonUtils::parse ofVec3f") << skip_invalid_format;
+                if(!detail::has_keys(json, {"x", "y", "z"})) {
+                    ofLogVerbose("ofxJsonUtils::parse ofVec3f") << skip_invalid_format;
+                    return;
+                }
                 v.set(json["x"], json["y"], json["z"]);
             } else if(json.is_array()) {
-                if(json.size() < 3) return ofLogVerbose("ofxJsonUtils::parse ofVec3f") << skip_invalid_format;
+                if(json.size() < 3) {
+                    ofLogVerbose("ofxJsonUtils::parse ofVec3f") << skip_invalid_format;
+                    return;
+                }
                 v.set(json[0], json[1], json[2]);
             } else {
                 ofLogVerbose("ofxJsonUtils::parse ofVec3f") << skip_json_isnt_object_or_array;
@@ -96,10 +114,16 @@ namespace ofx {
         static void parse(const ofJson &json, ofVec4f &v) {
             if(json.is_object()) {
                 auto end = json.end();
-                if(!detail::has_keys(json, {"x", "y", "z", "w"})) return ofLogVerbose("ofxJsonUtils::parse ofVec4f") << skip_invalid_format;
+                if(!detail::has_keys(json, {"x", "y", "z", "w"})) {
+                    ofLogVerbose("ofxJsonUtils::parse ofVec4f") << skip_invalid_format;
+                    return;
+                }
                 v.set(json["x"], json["y"], json["z"], json["w"]);
             } else if(json.is_array()) {
-                if(json.size() < 4) return ofLogVerbose("ofxJsonUtils::parse ofVec4f") << skip_invalid_format;
+                if(json.size() < 4) {
+                    ofLogVerbose("ofxJsonUtils::parse ofVec4f") << skip_invalid_format;
+                    return;
+                }
                 v.set(json[0], json[1], json[2], json[3]);
             } else {
                 ofLogVerbose("ofxJsonUtils::parse ofVec4f") << skip_json_isnt_object_or_array;
@@ -109,10 +133,16 @@ namespace ofx {
         static void parse(const ofJson &json, ofRectangle &rect) {
             if(json.is_object()) {
                 auto end = json.end();
-                if(!detail::has_keys(json, {"x", "y", "width", "height"})) return ofLogVerbose("ofxJsonUtils::parse ofRectangle") << skip_invalid_format;
+                if(!detail::has_keys(json, {"x", "y", "width", "height"})) {
+                    ofLogVerbose("ofxJsonUtils::parse ofRectangle") << skip_invalid_format;
+                    return;
+                }
                 rect.set(json["x"], json["y"], json["width"], json["height"]);
             } else if(json.is_array()) {
-                if(json.size() < 4) return ofLogVerbose("ofxJsonUtils::parse ofRectangle") << skip_invalid_format;
+                if(json.size() < 4) {
+                    ofLogVerbose("ofxJsonUtils::parse ofRectangle") << skip_invalid_format;
+                    return;
+                }
                 rect.set(json[0], json[1], json[2], json[3]);
             } else {
                 ofLogVerbose("ofxJsonUtils::parse ofRectangle") << skip_json_isnt_object_or_array;
@@ -122,14 +152,19 @@ namespace ofx {
         static void parse(const ofJson &json, ofMatrix4x4 &mat) {
             if(json.is_object()) {
                 auto end = json.end();
-                if(!detail::has_keys(json, {"value0", "value1", "value2", "value3"})) return
+                if(!detail::has_keys(json, {"value0", "value1", "value2", "value3"})) {
                     ofLogVerbose("ofxJsonUtils::parse ofMatrix4x4") << skip_invalid_format;
+                    return;
+                }
                 parse(json["value0"].get<ofJson::object_t>(), mat._mat[0]);
                 parse(json["value1"].get<ofJson::object_t>(), mat._mat[1]);
                 parse(json["value2"].get<ofJson::object_t>(), mat._mat[2]);
                 parse(json["value3"].get<ofJson::object_t>(), mat._mat[3]);
             } else if(json.is_array()) {
-                if(json.size() < 16) return ofLogVerbose("ofxJsonUtils::parse ofMatrix4x4") << skip_invalid_format;
+                if(json.size() < 16) {
+                    ofLogVerbose("ofxJsonUtils::parse ofMatrix4x4") << skip_invalid_format;
+                    return;
+                }
                 mat.set(json[0], json[1], json[2], json[3], json[4], json[5], json[6], json[7], json[8], json[9], json[10], json[11], json[12], json[13], json[14], json[15]);
             } else {
                 ofLogVerbose("ofxJsonUtils::parse ofMatrix4x4") << skip_json_isnt_object_or_array;


### PR DESCRIPTION
Visual Studio 2015 does not compile `return ofLogVerbose(...) << ...`. So I replaced them with the classic way.